### PR TITLE
Identify jQuery as a dependency of the theme's JS

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -20,10 +20,8 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 		$css_version = $theme_version . '.' . filemtime( get_template_directory() . '/css/theme.min.css' );
 		wp_enqueue_style( 'understrap-styles', get_template_directory_uri() . '/css/theme.min.css', array(), $css_version );
 
-		wp_enqueue_script( 'jquery' );
-
 		$js_version = $theme_version . '.' . filemtime( get_template_directory() . '/js/theme.min.js' );
-		wp_enqueue_script( 'understrap-scripts', get_template_directory_uri() . '/js/theme.min.js', array(), $js_version, true );
+		wp_enqueue_script( 'understrap-scripts', get_template_directory_uri() . '/js/theme.min.js', array( 'jquery' ), $js_version, true );
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 			wp_enqueue_script( 'comment-reply' );
 		}


### PR DESCRIPTION
Avoid the need to separately enqueue jQuery and establish the dependency when enqueuing the theme's JS.